### PR TITLE
Added missing dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "codelyzer": "~3.0.1",
     "core-js": "^2.4.1",
     "del": "^2.2.2",
+    "glob": "^7.1.2",
     "gulp": "^3.9.1",
     "gulp-rename": "^1.2.2",
     "gulp-rollup": "^2.11.0",


### PR DESCRIPTION
Development step `npm run build:watch` will not run without adding this missing dev dependency, required by the `inline-resources.js` file.