### PR TITLE
RXJS 6 support

### DIFF
--- a/example/app/app.component.ts
+++ b/example/app/app.component.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {Observable} from 'rxjs/Observable';
+import {Observable} from 'rxjs';
 import {SnotifyService, SnotifyPosition, SnotifyToastConfig} from 'ng-snotify';
 
 @Component({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,10 +78,8 @@ gulp.task('rollup:fesm', function () {
       external: [
         '@angular/core',
         '@angular/common',
-        'rxjs/Subject',
+        'rxjs',
         'rxjs/observable/PromiseObservable',
-        'rxjs/Observable',
-        'rxjs/Subscription',
       ],
 
       // Format of generated bundle
@@ -115,10 +113,8 @@ gulp.task('rollup:umd', function () {
       external: [
         '@angular/core',
         '@angular/common',
-        'rxjs/Subject',
+        'rxjs',
         'rxjs/observable/PromiseObservable',
-        'rxjs/Observable',
-        'rxjs/Subscription',
       ],
 
       // Format of generated bundle
@@ -139,7 +135,7 @@ gulp.task('rollup:umd', function () {
         typescript: 'ts',
         '@angular/core': '@angular/core',
         '@angular/common': '@angular/common',
-        'rxjs/Subject': 'rxjs/Subject',
+        'rxjs': 'rxjs',
         'rxjs/observable/PromiseObservable': 'rxjs/observable/PromiseObservable',
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-snotify",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/snotify/snotify.component.ts
+++ b/src/snotify/snotify.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnDestroy, OnInit, ViewEncapsulation} from '@angular/core';
 import {SnotifyService} from './snotify.service';
 import {SnotifyToast} from './toast/snotify-toast.model';
-import {Subscription} from 'rxjs/Subscription';
+import {Subscription} from 'rxjs';
 import {SnotifyNotifications} from './interfaces/SnotifyNotifications.interface';
 import {SnotifyPosition} from './enums/SnotifyPosition.enum';
 import {SnotifyEvent} from './types/event.type';

--- a/src/snotify/snotify.service.ts
+++ b/src/snotify/snotify.service.ts
@@ -1,9 +1,7 @@
 import {Inject, Injectable} from '@angular/core';
 import {SnotifyToast} from './toast/snotify-toast.model';
-import {Subject} from 'rxjs/Subject';
-import {Observable} from 'rxjs/Observable';
+import {Observable, Subject, Subscription} from 'rxjs';
 import {PromiseObservable} from 'rxjs/observable/PromiseObservable';
-import {Subscription} from 'rxjs/Subscription';
 import {SnotifyToastConfig} from './interfaces/SnotifyToastConfig.interface';
 import {Snotify} from './interfaces/Snotify.interface';
 import {SnotifyStyle} from './enums/SnotifyStyle.enum';

--- a/src/snotify/toast/snotify-toast.model.ts
+++ b/src/snotify/toast/snotify-toast.model.ts
@@ -1,8 +1,7 @@
 import {SnotifyToastConfig} from '../interfaces/SnotifyToastConfig.interface';
-import {Subject} from 'rxjs/Subject';
+import {Subject, Subscription} from 'rxjs';
 import {SnotifyEvent} from '../types/event.type';
 import {SnotifyStyle} from '../enums/SnotifyStyle.enum';
-import {Subscription} from 'rxjs/Subscription';
 // @TODO remove method in observable way
 /**
  * Toast main model

--- a/src/snotify/toast/toast.component.ts
+++ b/src/snotify/toast/toast.component.ts
@@ -4,7 +4,7 @@ import {
 } from '@angular/core';
 import {SnotifyService} from '../snotify.service';
 import {SnotifyToast} from './snotify-toast.model';
-import {Subscription} from 'rxjs/Subscription';
+import {Subscription} from 'rxjs';
 import {SnotifyStyle} from '../enums/SnotifyStyle.enum';
 import {SnotifyEvent} from '../types/event.type';
 

--- a/tslint.json
+++ b/tslint.json
@@ -13,10 +13,6 @@
     "curly": true,
     "eofline": true,
     "forin": true,
-    "import-blacklist": [
-      true,
-      "rxjs"
-    ],
     "import-spacing": true,
     "indent": [
       true,


### PR DESCRIPTION
This PR adds RXJS 6 support, but is also backwards-compatible with v5.

Switched `import * from 'rxjs/{Observable,Subject}'` to `import {Observable, Subject} from 'rxjs'` according to official [rxjs migration guide](https://github.com/ReactiveX/rxjs/blob/master/MIGRATION.md).

With this PR this library is also Angular 6 compatible. It fixes #42 