### PR TITLE
upd: project to use `strictNullChecks`

### DIFF
--- a/example/app/app.component.spec.ts
+++ b/example/app/app.component.spec.ts
@@ -1,9 +1,9 @@
 /* tslint:disable:no-unused-variable */
 
-import { FormsModule } from '@angular/forms';
-import { TestBed, ComponentFixture, async } from '@angular/core/testing';
-import { AppComponent } from './app.component';
-import {SnotifyModule, SnotifyService, ToastDefaults} from 'ng-snotify';
+import {FormsModule} from '@angular/forms';
+import {TestBed, ComponentFixture, async} from '@angular/core/testing';
+import {AppComponent} from './app.component';
+import {SnotifyModule, SnotifyService, ToastDefaults, SnotifyToast} from 'ng-snotify';
 import {SnotifyPosition} from '../../src/snotify/enums/SnotifyPosition.enum';
 
 describe('NgSnotify Testing', () => {
@@ -69,12 +69,12 @@ describe('NgSnotify Testing', () => {
   });
 
   it('should execute confirm button action', (done) => {
-    let result = null;
+    let result: SnotifyToast | null = null;
     const service: SnotifyService = fixture.debugElement.injector.get(SnotifyService);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
 
-    const toastID = service.confirm('Ng-Snotify', null, {
+    const toastID = service.confirm('Ng-Snotify', {
       buttons: [
         {text: 'Yes', action: (id) => result = id}
       ]
@@ -82,7 +82,7 @@ describe('NgSnotify Testing', () => {
     fixture.detectChanges();
     compiled.querySelector('.snotifyToast button').click();
 
-    expect(result).toEqual(toastID);
+    expect(result as SnotifyToast | null).toEqual(toastID);
     done();
   });
 
@@ -91,7 +91,7 @@ describe('NgSnotify Testing', () => {
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
 
-    service.prompt('Ng-Snotify', null, {
+    service.prompt('Ng-Snotify', {
       buttons: [
         {text: 'Yes'},
         {text: 'Yes'},
@@ -143,10 +143,10 @@ describe('NgSnotify Testing', () => {
     const service: SnotifyService = fixture.debugElement.injector.get(SnotifyService);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
-    service.simple('Test', null, {
+    service.simple('Test', {
       position: SnotifyPosition.centerBottom
     });
-    service.success('Test', null, {
+    service.success('Test', {
       position: SnotifyPosition.leftBottom
     });
     fixture.detectChanges();

--- a/src/snotify/interfaces/ProcessedSnotifyDefaults.interface.ts
+++ b/src/snotify/interfaces/ProcessedSnotifyDefaults.interface.ts
@@ -1,0 +1,46 @@
+import {SnotifyStyle} from '../enums/SnotifyStyle.enum';
+import {SnotifyType} from '../types/snotify.type';
+import {SnotifyAnimate} from './SnotifyAnimate.interface';
+import {SafeHtml} from '@angular/platform-browser';
+import {SnotifyPosition} from '../enums/SnotifyPosition.enum';
+import {SnotifyButton} from './SnotifyButton.interface';
+import {SnotifyToastConfig} from './SnotifyToastConfig.interface';
+import {SnotifyToast} from '../toast/snotify-toast.model';
+
+export interface ProcessedSnotifyGlobalConfig {
+  maxOnScreen: number;
+  maxAtPosition: number;
+  newOnTop: boolean;
+}
+
+/**
+ * Toast configuration object after user provided defaults are merged with standard defaults
+ */
+export interface ProcessedSnotifyToastConfig {
+  timeout: number;
+  showProgressBar: boolean;
+  type: SnotifyType;
+  closeOnClick: boolean;
+  pauseOnHover: boolean;
+  buttons?: SnotifyButton[];
+  placeholder?: string;
+  titleMaxLength: number;
+  bodyMaxLength: number;
+  icon: string | null;
+  iconClass: string | null;
+  backdrop: number;
+  animation: SnotifyAnimate;
+  html: string | SafeHtml | null;
+  position: SnotifyPosition;
+}
+
+/**
+ * Global configuration object after user provided defaults are merged with standard defaults
+ */
+export interface ProcessedSnotifyDefaults {
+  global: ProcessedSnotifyGlobalConfig,
+  toast: ProcessedSnotifyToastConfig,
+  type: {
+    [key: string]: SnotifyToastConfig,
+  }
+}

--- a/src/snotify/interfaces/SnotifyButton.interface.ts
+++ b/src/snotify/interfaces/SnotifyButton.interface.ts
@@ -19,7 +19,7 @@ export interface SnotifyButton {
    * @returns {void}
    * @default this.remove(id)
    */
-  action?: (toast: SnotifyToast) => void;
+  action?: ((toast: SnotifyToast) => void) | null;
   /**
    * Should button text be bold.
    */

--- a/src/snotify/pipes/keys.pipe.ts
+++ b/src/snotify/pipes/keys.pipe.ts
@@ -8,7 +8,7 @@ import { Pipe, PipeTransform } from '@angular/core';
  * Extract object keys pipe
  */
 export class KeysPipe implements PipeTransform {
-  transform(value: any, args: any[] = null): any {
+  transform(value: any, args: any[] | null = null): any {
     if (!value) {
       return value;
     }

--- a/src/snotify/snotify.service.ts
+++ b/src/snotify/snotify.service.ts
@@ -10,6 +10,8 @@ import {TransformArgument} from './decorators/transform-argument.decorator';
 import {mergeDeep, uuid} from './utils';
 import {SetToastType} from './decorators/set-toast-type.decorator';
 import {SnotifyDefaults} from './interfaces/SnotifyDefaults.interface';
+import {ToastDefaults} from './toastDefaults';
+import {ProcessedSnotifyDefaults, ProcessedSnotifyToastConfig} from './interfaces/ProcessedSnotifyDefaults.interface';
 
 /**
  * SnotifyService - create, remove, config toasts
@@ -22,7 +24,10 @@ export class SnotifyService {
   readonly toastDeleted = new Subject<number>();
   private notifications: SnotifyToast[] = [];
 
-  constructor(@Inject('SnotifyToastConfig') public config: SnotifyDefaults) {
+  public config: ProcessedSnotifyDefaults;
+
+  constructor(@Inject('SnotifyToastConfig') config: SnotifyDefaults) {
+    this.config = mergeDeep(ToastDefaults, config) as ProcessedSnotifyDefaults;
   }
   /**
    * emit changes in notifications array
@@ -36,7 +41,7 @@ export class SnotifyService {
    * @param id {Number}
    * @return {SnotifyToast|undefined}
    */
-  get(id: number): SnotifyToast {
+  get(id: number): SnotifyToast | undefined {
     return this.notifications.find(toast => toast.id === id);
   }
 
@@ -82,8 +87,8 @@ export class SnotifyService {
    * @return {number}
    */
   create(snotify: Snotify): SnotifyToast {
-    const config =
-      mergeDeep(this.config.toast, this.config.type[snotify.config.type], snotify.config);
+    const typeConfig = (snotify.config && snotify.config.type ? this.config.type[snotify.config.type] : {});
+    const config = mergeDeep(this.config.toast, typeConfig, snotify.config) as ProcessedSnotifyToastConfig;
     const toast = new SnotifyToast(
       uuid(),
       snotify.title,
@@ -94,8 +99,8 @@ export class SnotifyService {
     return toast;
   }
 
-  setDefaults(defaults: SnotifyDefaults): SnotifyDefaults {
-    return this.config = mergeDeep(this.config, defaults) as SnotifyDefaults;
+  setDefaults(defaults: SnotifyDefaults): ProcessedSnotifyDefaults {
+    return this.config = mergeDeep(this.config, defaults) as ProcessedSnotifyDefaults;
   }
 
   /**
@@ -476,8 +481,6 @@ export class SnotifyService {
    */
   html(html: string | SafeHtml, config?: SnotifyToastConfig): SnotifyToast {
     return this.create({
-      title: null,
-      body: null,
       config: {
         ...config,
         ...{html}

--- a/src/snotify/toast/snotify-toast.model.ts
+++ b/src/snotify/toast/snotify-toast.model.ts
@@ -2,6 +2,7 @@ import {SnotifyToastConfig} from '../interfaces/SnotifyToastConfig.interface';
 import {Subject, Subscription} from 'rxjs';
 import {SnotifyEvent} from '../types/event.type';
 import {SnotifyStyle} from '../enums/SnotifyStyle.enum';
+import {ProcessedSnotifyToastConfig} from '../interfaces/ProcessedSnotifyDefaults.interface';
 // @TODO remove method in observable way
 /**
  * Toast main model
@@ -27,9 +28,9 @@ export class SnotifyToast {
    */
   valid: boolean;
   constructor (public id: number,
-               public title: string,
-               public body: string,
-               public config: SnotifyToastConfig) {
+               public title: string | undefined,
+               public body: string | undefined,
+               public config: ProcessedSnotifyToastConfig) {
     if (this.config.type === SnotifyStyle.prompt) {
       this.value = '';
     }

--- a/src/snotify/toastDefaults.ts
+++ b/src/snotify/toastDefaults.ts
@@ -1,11 +1,11 @@
 import {SnotifyPosition} from './enums/SnotifyPosition.enum';
 import {SnotifyStyle} from './enums/SnotifyStyle.enum';
+import {ProcessedSnotifyDefaults} from './interfaces/ProcessedSnotifyDefaults.interface';
 
 /**
  * Snotify default configuration object
- * @type {SnotifyDefaults}
  */
-export const ToastDefaults = {
+export const ToastDefaults: ProcessedSnotifyDefaults = {
   global: {
     newOnTop: true,
     maxOnScreen: 8,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "./demo-example/out-tsc",
+    "strictNullChecks": true,
     "baseUrl": "demo-example",
     "sourceMap": true,
     "declaration": false,


### PR DESCRIPTION
Hey there! Thanks for all your work on this package. In my angular project (using `strictNullChecks: true`), I was running into a type error coming from ng-snotify within node_modules. Initially, I tried to figure out how to suppress type checking from node_modules (for some reason `skipLibCheck` doesn't seem to do it...), but after a little bit I decided a better use of my time would simply be upgrading this package to be `strictNullChecks` safe for all. So that's what I've done.

This is a non-breaking, relatively minor update which fixes some type annotations within ng-snotify. It also introduces a new, private interface `ProcessedSnotifyDefaults`. Most of the type problems stemmed from the fact that the `SnotifyDefaults` object, which a user can provide, is merged into the `ToastDefaults` object so that a bunch of the properties are never actually `undefined` (even though the `SnotifyDefaults` interface specifies that they can be). The new `ProcessedSnotifyDefaults` interface more accurately types properties as undefined or not.

While it's not....strictly (<--get it???)....necessary to fix the bug I was running into, I also updated `tsconfig.json` with `strictNullChecks: true` to help prevent type regressions in the future.

I've added some additional comments to the code.

Let me know if there are any issues. The tests all pass on my computer.