### PR TITLE
Fix #63 - New line in text

### DIFF
--- a/projects/ng-snotify/styles/dark/toast.scss
+++ b/projects/ng-snotify/styles/dark/toast.scss
@@ -71,6 +71,7 @@ $snotify-body-font-size: auto !default;
   &__body {
     font-size: $snotify-body-font-size;
     color: $toast-color;
+    white-space: pre-line;
   }
 }
 

--- a/projects/ng-snotify/styles/material/toast.scss
+++ b/projects/ng-snotify/styles/material/toast.scss
@@ -103,6 +103,7 @@ $snotify-body-font-size: auto !default;
 
   &__body {
     font-size: $snotify-body-font-size;
+    white-space: pre-line;
   }
 }
 

--- a/projects/ng-snotify/styles/simple/toast.scss
+++ b/projects/ng-snotify/styles/simple/toast.scss
@@ -81,6 +81,7 @@ $snotify-body-font-size: auto !default;
   &__body {
     font-size: $snotify-body-font-size;
     color: $toast-color;
+    white-space: pre-line;
   }
 }
 


### PR DESCRIPTION
Newline support added for the toast body by setting the white-space property to pre-line in the toast.scss files.

Ref:
[1] [developer.mozilla.org : white-space property](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space)
